### PR TITLE
Install the latest Ansbile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN apt update && apt -y upgrade
 # Add the ability to use PPAs
 RUN apt -y install gnupg2
 
-# Install Ansible
-RUN apt -y install ansible
+# Install latest Ansible using pip
+RUN apt -y install pip
+RUN pip install ansible
 
 # Install Rsync to allow use of ansible.posix.synchronise
 RUN apt -y install rsync


### PR DESCRIPTION
The previous version of Ansbile provided by the base image package
manager is out of date. Using pip to install Ansible provides the latest
version.